### PR TITLE
댓글 CRUD 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'com.zaxxer:HikariCP:5.0.1'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/code/backend/BackendApplication.java
+++ b/backend/src/main/java/com/code/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.code.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/code/backend/controller/ArticleController.java
+++ b/backend/src/main/java/com/code/backend/controller/ArticleController.java
@@ -4,12 +4,14 @@ import com.code.backend.dto.EditArticleDto;
 import com.code.backend.dto.WriteArticleDto;
 import com.code.backend.entity.Article;
 import com.code.backend.service.ArticleService;
+import com.code.backend.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("/api/boards")
@@ -17,11 +19,13 @@ public class ArticleController {
 
     private final AuthenticationManager authenticationManager;
     private final ArticleService articleService;
+    private final CommentService commentService;
 
     @Autowired
-    public ArticleController(AuthenticationManager authenticationManager, ArticleService articleService) {
+    public ArticleController(AuthenticationManager authenticationManager, ArticleService articleService, CommentService commentService) {
         this.authenticationManager = authenticationManager;
         this.articleService = articleService;
+        this.commentService = commentService;
     }
 
     @PostMapping("/{boardId}/articles")
@@ -53,5 +57,11 @@ public class ArticleController {
     public ResponseEntity<String> deleteArticle(@PathVariable Long boardId, @PathVariable Long articleId) {
         articleService.deleteArticle(boardId, articleId);
         return ResponseEntity.ok("article is deleted");
+    }
+
+    @GetMapping("/{boardId}/articles/{articleId}")
+    public ResponseEntity<Article> getArticleWithComment(@PathVariable Long boardId, @PathVariable Long articleId) {
+        CompletableFuture<Article> article = commentService.getArticleWithComment(boardId, articleId);
+        return ResponseEntity.ok(article.resultNow());
     }
 }

--- a/backend/src/main/java/com/code/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/code/backend/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.code.backend.controller;
 
+import com.code.backend.dto.EditCommentDto;
 import com.code.backend.dto.WriteCommentDto;
 import com.code.backend.entity.Comment;
 import com.code.backend.service.CommentService;
@@ -18,11 +19,19 @@ public class CommentController {
         this.commentService = commentService;
     }
 
-    @PostMapping("/{boardId}/articles/{articleId}")
+    @PostMapping("/{boardId}/articles/{articleId}/comments")
     public ResponseEntity<Comment> writeComment(@PathVariable Long boardId,
                                                 @PathVariable Long articleId,
                                                 @RequestBody WriteCommentDto writeCommentDto) {
         return ResponseEntity.ok(commentService.writeComment(boardId, articleId, writeCommentDto));
+    }
+
+    @PutMapping("/{boardId}/articles/{articleId}/comments/{commentId}")
+    public ResponseEntity<Comment> writeComment(@PathVariable Long boardId,
+                                                @PathVariable Long articleId,
+                                                @PathVariable Long commentId,
+                                                @RequestBody EditCommentDto editCommentDto) {
+        return ResponseEntity.ok(commentService.editComment(boardId, articleId, commentId, editCommentDto));
     }
 
 

--- a/backend/src/main/java/com/code/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/code/backend/controller/CommentController.java
@@ -1,0 +1,29 @@
+package com.code.backend.controller;
+
+import com.code.backend.dto.WriteCommentDto;
+import com.code.backend.entity.Comment;
+import com.code.backend.service.CommentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/boards")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Autowired
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @PostMapping("/{boardId}/articles/{articleId}")
+    public ResponseEntity<Comment> writeComment(@PathVariable Long boardId,
+                                                @PathVariable Long articleId,
+                                                @RequestBody WriteCommentDto writeCommentDto) {
+        return ResponseEntity.ok(commentService.writeComment(boardId, articleId, writeCommentDto));
+    }
+
+
+}

--- a/backend/src/main/java/com/code/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/code/backend/controller/CommentController.java
@@ -34,5 +34,13 @@ public class CommentController {
         return ResponseEntity.ok(commentService.editComment(boardId, articleId, commentId, editCommentDto));
     }
 
+    @DeleteMapping("/{boardId}/articles/{articleId}/comments/{commentId}")
+    public ResponseEntity<String> writeComment(@PathVariable Long boardId,
+                                                @PathVariable Long articleId,
+                                                @PathVariable Long commentId) {
+        commentService.deleteComment(boardId, articleId, commentId);
+        return ResponseEntity.ok("comment is deleted");
+    }
+
 
 }

--- a/backend/src/main/java/com/code/backend/dto/EditCommentDto.java
+++ b/backend/src/main/java/com/code/backend/dto/EditCommentDto.java
@@ -1,0 +1,8 @@
+package com.code.backend.dto;
+
+import lombok.Getter;
+
+@Getter
+public class EditCommentDto {
+    String content;
+}

--- a/backend/src/main/java/com/code/backend/dto/WriteCommentDto.java
+++ b/backend/src/main/java/com/code/backend/dto/WriteCommentDto.java
@@ -1,0 +1,8 @@
+package com.code.backend.dto;
+
+import lombok.Getter;
+
+@Getter
+public class WriteCommentDto {
+    String content;
+}

--- a/backend/src/main/java/com/code/backend/entity/Article.java
+++ b/backend/src/main/java/com/code/backend/entity/Article.java
@@ -9,6 +9,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -35,6 +37,10 @@ public class Article {
     @JsonIgnore
     @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.CONSTRAINT))
     private Board board;
+
+    @OneToMany
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private List<Comment> comments = new ArrayList<>();
 
     @Column(nullable = false)
     private Boolean isDeleted = false;

--- a/backend/src/main/java/com/code/backend/entity/Comment.java
+++ b/backend/src/main/java/com/code/backend/entity/Comment.java
@@ -1,0 +1,55 @@
+package com.code.backend.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.CONSTRAINT))
+    private User author;
+
+    @ManyToOne
+    @JsonIgnore
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.CONSTRAINT))
+    private Article article;
+
+    @Column(nullable = false)
+    private Boolean isDeleted = false;
+
+    @CreatedDate
+    @Column(insertable = true)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdDate = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedDate = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/code/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/code/backend/repository/CommentRepository.java
@@ -1,0 +1,21 @@
+package com.code.backend.repository;
+
+import com.code.backend.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("SELECT c FROM Comment c JOIN c.author u WHERE u.username = :username ORDER BY c.createdDate DESC LIMIT 1")
+    Comment findLatestCommentOrderByCreatedDate(@Param("username") String username);
+
+    @Query("SELECT c FROM Comment c JOIN c.author u WHERE u.username = :username ORDER BY c.updatedDate DESC LIMIT 1")
+    Comment findLatestCommentOrderByUpdatedDate(@Param("username") String username);
+
+    @Query("SELECT c FROM Comment c WHERE c.article.id = :articleId AND c.isDeleted = false")
+    List<Comment> findByArticleId(@Param("articleId") Long articleId);
+}

--- a/backend/src/main/java/com/code/backend/service/ArticleService.java
+++ b/backend/src/main/java/com/code/backend/service/ArticleService.java
@@ -152,6 +152,9 @@ public class ArticleService {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         Article latestArticle = articleRepository.findLatestArticleByAuthorUsernameOrderByCreatedDate(userDetails.getUsername());
+        if (latestArticle == null) {
+            return true;
+        }
         return this.isDifferenceMoreThanFiveMinutes(latestArticle.getCreatedDate());
     }
 
@@ -159,6 +162,9 @@ public class ArticleService {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         Article latestArticle = articleRepository.findLatestArticleByAuthorUsernameOrderByUpdatedDate(userDetails.getUsername());
+        if (latestArticle == null || latestArticle.getUpdatedDate() == null) {
+            return true;
+        }
         return this.isDifferenceMoreThanFiveMinutes(latestArticle.getUpdatedDate());
     }
 

--- a/backend/src/main/java/com/code/backend/service/ArticleService.java
+++ b/backend/src/main/java/com/code/backend/service/ArticleService.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -38,6 +39,7 @@ public class ArticleService {
         this.userRepository = userRepository;
     }
 
+    @Transactional
     public Article writeArticle(Long boardId, WriteArticleDto dto) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
@@ -78,6 +80,7 @@ public class ArticleService {
         return articleRepository.findTop10ByBoardIdAndArticleIdGreaterThanOrderByCreatedDateDesc(boardId, articleId);
     }
 
+    @Transactional
     public Article editArticle(Long boardId, Long articleId, EditArticleDto dto) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
@@ -117,6 +120,7 @@ public class ArticleService {
         return article.get();
     }
 
+    @Transactional
     public boolean deleteArticle(Long boardId, Long articleId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/backend/src/main/java/com/code/backend/service/CommentService.java
+++ b/backend/src/main/java/com/code/backend/service/CommentService.java
@@ -122,6 +122,43 @@ public class CommentService {
         return comment.get();
     }
 
+    public boolean deleteComment(Long boardId, Long articleId, Long commentId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        // rate limit 체크
+        if (!this.isCanEditComment()) {
+            throw new RateLimitException("comment not written by rate limit");
+        }
+
+        Optional<User> author = userRepository.findByUsername(userDetails.getUsername());
+        Optional<Board> board = boardRepository.findById(boardId);
+        Optional<Article> article = articleRepository.findById(articleId);
+
+        if (author.isEmpty()) {
+            throw new ResourceNotFoundException("author not found");
+        }
+        if (board.isEmpty()) {
+            throw new ResourceNotFoundException("board not found");
+        }
+        if (article.isEmpty()) {
+            throw new ResourceNotFoundException("article not found");
+        }
+        if (article.get().getIsDeleted()) {
+            throw new ForbiddenException("article is deleted");
+        }
+        Optional<Comment> comment = commentRepository.findById(commentId);
+        if (comment.isEmpty()) {
+            throw new ResourceNotFoundException("comment not found");
+        }
+        if (comment.get().getAuthor() != author.get()) {
+            throw new ForbiddenException("comment author different");
+        }
+        comment.get().setIsDeleted(true);
+        commentRepository.save(comment.get());
+        return true;
+    }
+
     private boolean isCanWriteComment() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/backend/src/main/java/com/code/backend/service/CommentService.java
+++ b/backend/src/main/java/com/code/backend/service/CommentService.java
@@ -1,0 +1,108 @@
+package com.code.backend.service;
+
+import com.code.backend.dto.WriteCommentDto;
+import com.code.backend.entity.Article;
+import com.code.backend.entity.Board;
+import com.code.backend.entity.Comment;
+import com.code.backend.entity.User;
+import com.code.backend.exception.ForbiddenException;
+import com.code.backend.exception.RateLimitException;
+import com.code.backend.exception.ResourceNotFoundException;
+import com.code.backend.repository.ArticleRepository;
+import com.code.backend.repository.BoardRepository;
+import com.code.backend.repository.CommentRepository;
+import com.code.backend.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+public class CommentService {
+
+    private final BoardRepository boardRepository;
+    private final ArticleRepository articleRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+
+
+    @Autowired
+    public CommentService(BoardRepository boardRepository, ArticleRepository articleRepository, UserRepository userRepository, CommentRepository commentRepository) {
+        this.boardRepository = boardRepository;
+        this.articleRepository = articleRepository;
+        this.userRepository = userRepository;
+        this.commentRepository = commentRepository;
+    }
+
+    @Transactional
+    public Comment writeComment(Long boardId, Long articleId, WriteCommentDto dto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        // rate limit 체크
+        if (!this.isCanWriteComment()) {
+            throw new RateLimitException("article not written by rate limit");
+        }
+
+        Optional<User> author = userRepository.findByUsername(userDetails.getUsername());
+        Optional<Board> board = boardRepository.findById(boardId);
+        Optional<Article> article = articleRepository.findById(articleId);
+
+        if (author.isEmpty()) {
+            throw new ResourceNotFoundException("author not found");
+        }
+        if (board.isEmpty()) {
+            throw new ResourceNotFoundException("board not found");
+        }
+        if (article.isEmpty()) {
+            throw new ResourceNotFoundException("article not found");
+        }
+        if (article.get().getIsDeleted()) {
+            throw new ForbiddenException("article is deleted");
+        }
+
+        Comment comment = new Comment();
+        comment.setArticle(article.get());
+        comment.setAuthor(author.get());
+        comment.setContent(dto.getContent());
+        commentRepository.save(comment);
+        return comment;
+    }
+    private boolean isCanWriteComment() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        Comment latestComment = commentRepository.findLatestCommentOrderByCreatedDate(userDetails.getUsername());
+        if (latestComment == null) {
+            return true;
+        }
+        return this.isDifferenceMoreThanOneMinutes(latestComment.getCreatedDate());
+    }
+
+    private boolean isCanEditComment() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        Comment latestComment = commentRepository.findLatestCommentOrderByUpdatedDate(userDetails.getUsername());
+        if (latestComment == null) {
+            return true;
+        }
+        return this.isDifferenceMoreThanOneMinutes(latestComment.getUpdatedDate());
+    }
+
+    private boolean isDifferenceMoreThanOneMinutes(LocalDateTime localDateTime) {
+        LocalDateTime dateAsLocalDateTime = new Date().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+
+        Duration duration = Duration.between(localDateTime, dateAsLocalDateTime);
+
+        return Math.abs(duration.toMinutes()) > 1;
+    }
+}

--- a/backend/src/main/java/com/code/backend/service/CommentService.java
+++ b/backend/src/main/java/com/code/backend/service/CommentService.java
@@ -13,6 +13,7 @@ import com.code.backend.repository.BoardRepository;
 import com.code.backend.repository.CommentRepository;
 import com.code.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -23,7 +24,10 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 @Service
 public class CommentService {
@@ -76,6 +80,7 @@ public class CommentService {
         commentRepository.save(comment);
         return comment;
     }
+
     private boolean isCanWriteComment() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
@@ -104,5 +109,41 @@ public class CommentService {
         Duration duration = Duration.between(localDateTime, dateAsLocalDateTime);
 
         return Math.abs(duration.toMinutes()) > 1;
+    }
+
+    @Async
+    protected CompletableFuture<Article> getArticle(Long boardId, Long articleId) {
+        Optional<Board> board = boardRepository.findById(boardId);
+        if (board.isEmpty()) {
+            throw new ResourceNotFoundException("board not found");
+        }
+        Optional<Article> article = articleRepository.findById(articleId);
+        if (article.isEmpty() || article.get().getIsDeleted()) {
+            throw new ResourceNotFoundException("article not found");
+        }
+        return CompletableFuture.completedFuture(article.get());
+    }
+
+    @Async
+    protected CompletableFuture<List<Comment>> getComments(Long articleId) {
+        return CompletableFuture.completedFuture(commentRepository.findByArticleId(articleId));
+    }
+
+    public CompletableFuture<Article> getArticleWithComment(Long boardId, Long articleId) {
+        CompletableFuture<Article> articleFuture = this.getArticle(boardId, articleId);
+        CompletableFuture<List<Comment>> commentsFuture = this.getComments(articleId);
+
+        return CompletableFuture.allOf(articleFuture, commentsFuture)
+                .thenApply(voidResult -> {
+                    try {
+                        Article article = articleFuture.get();
+                        List<Comment> comments = commentsFuture.get();
+                        article.setComments(comments);
+                        return article;
+                    } catch (InterruptedException | ExecutionException e) {
+                        e.printStackTrace();
+                        return null;
+                    }
+                });
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,3 +13,12 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 # Hibernate ??
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# HikariCP ??
+spring.datasource.hikari.pool-name=HikariCP
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.idle-timeout=30000
+spring.datasource.hikari.connection-timeout=20000
+spring.datasource.hikari.max-lifetime=1800000
+spring.datasource.hikari.connection-test-query=SELECT 1


### PR DESCRIPTION
- 동시성 처리를 위한 트랜잭션 처리
- rate limit 통해 댓글은 1분에 1번만 작성 가능 하도록 제한
- 0.1초라도 빨리 보여주기 위해 비동기형 호출 방식을 사용
- connection 을 api 한번 호출할 때 DB 에다 쿼리를 동시에 여러 개 호출
- connection pool 사용 
- HikariCP  설정